### PR TITLE
Hints skip already done prefetches.

### DIFF
--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -400,7 +400,7 @@ class QueryOptimizerStore:
             queryset = queryset.prefetch_related(
                 *[
                     prefetch_related_lookup
-                    for prefetch_related_lookup in self.prefetch_list
+                    for prefetch_related_lookup in list(dict.fromkeys(self.prefetch_list))
                     if not (
                         hasattr(queryset, "_prefetch_related_lookups")
                         and prefetch_related_lookup

--- a/graphene_django_optimizer/query.py
+++ b/graphene_django_optimizer/query.py
@@ -397,7 +397,17 @@ class QueryOptimizerStore:
             queryset = queryset.select_related(*self.select_list)
 
         if self.prefetch_list:
-            queryset = queryset.prefetch_related(*self.prefetch_list)
+            queryset = queryset.prefetch_related(
+                *[
+                    prefetch_related_lookup
+                    for prefetch_related_lookup in self.prefetch_list
+                    if not (
+                        hasattr(queryset, "_prefetch_related_lookups")
+                        and prefetch_related_lookup
+                        in queryset._prefetch_related_lookups
+                    )
+                ]
+            )
 
         if self.only_list:
             queryset = queryset.only(*self.only_list)


### PR DESCRIPTION
This PR solves the following problem:

When an optimizer hint with `prefetch_related` is applied to a queryset that already has this prefetch done by other means (same `to_attr`), Django raises the Exception "lookup was already seen with a different queryset. You may need to adjust the ordering of your lookups".

What we would like instead is for `graphene-django-optimizer` to detect that and not create the duplicate prefetch_related, thus not triggering the exception.

Hope this can be merged soon!